### PR TITLE
Update graphql query

### DIFF
--- a/github/members/query.graphql
+++ b/github/members/query.graphql
@@ -1,6 +1,6 @@
 query getMembers($limit: Int!, $cursor: String) {
   organization(login: "openmined") {
-    members(first: $limit, after: $cursor) {
+    membersWithRole(first: $limit, after: $cursor) {
       totalCount
       edges {
         cursor


### PR DESCRIPTION
Seems like that's the issue, why cron job stopped to work.

Currently If I run your query it fails with 
```
"message": "Field 'members' doesn't exist on type 'Organization'"
```
I also found a mention about this in docs, just a bit in the past. So might be Github had a graceful deprecation period

https://developer.github.com/v4/changelog/2019-07-19-schema-changes/